### PR TITLE
Change models to use short indices for ES 2.0 compliance

### DIFF
--- a/app/src/main/cpp/GLES2Renderer.cpp
+++ b/app/src/main/cpp/GLES2Renderer.cpp
@@ -353,7 +353,7 @@ void GLES2Renderer::initRenderModel(const RenderModel &model) {
                  model.geometry.vertexData.size() * sizeof(OBJParse::VertexAttributes),
                  &model.geometry.vertexData[0], GL_STATIC_DRAW);
     glBufferData(GL_ELEMENT_ARRAY_BUFFER,
-                 model.geometry.indexData.size() * sizeof(uint32_t),
+                 model.geometry.indexData.size() * sizeof(uint16_t),
                  &model.geometry.indexData[0], GL_STATIC_DRAW);
 
     glEnableVertexAttribArray(aPosLoc);
@@ -553,7 +553,7 @@ void GLES2Renderer::draw() {
                 changeRenderState(obj.renderHandle, true);
                 glUniformMatrix4fv(depthMapWorldMatrixLoc,
                                    1, GL_FALSE, (currentLightMatrix * obj.worldMatrix).vals);
-                glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_INT, 0);
+                glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_SHORT, 0);
             }
         }
 
@@ -591,7 +591,7 @@ void GLES2Renderer::draw() {
                                    1, GL_FALSE, currentCameraMatrix.vals);
                 glUniformMatrix4fv(shadowRenderLightMatrixLoc,
                                    1, GL_FALSE, currentLightMatrix.vals);
-                glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_INT, 0);
+                glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_SHORT, 0);
             }
         }
 
@@ -607,7 +607,7 @@ void GLES2Renderer::draw() {
                                1, GL_FALSE, (obj.worldMatrix).vals);
             glUniformMatrix4fv(currRenderState.uCameraMatrixLoc,
                                1, GL_FALSE, currentCameraMatrix.vals);
-            glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_INT, 0);
+            glDrawElements(GL_TRIANGLES, obj.indexCount, GL_UNSIGNED_SHORT, 0);
         }
     }
 

--- a/app/src/main/cpp/OBJParse.cpp
+++ b/app/src/main/cpp/OBJParse.cpp
@@ -92,10 +92,16 @@ OBJParse::OBJParse(const std::string &objFileName) {
 
     }
 
-    unsigned int actualIndexMapIndex = 0;
+    unsigned short actualIndexMapIndex = 0;
     for (auto it : vertexDataMap) {
         indexDataMap[it.first] = actualIndexMapIndex;
         actualIndexMapIndex++;
+        // check for overflow
+        if (actualIndexMapIndex == 0) {
+            // indicates that there are more than 2^16 distinct vertices,
+            // so indices won't fit in an unsigned short
+            __android_log_print(ANDROID_LOG_ERROR, "OBJParse", "out of indices!!!!!!!\n");
+        }
         vertexData.push_back(it.second);
     }
 

--- a/app/src/main/cpp/OBJParse.h
+++ b/app/src/main/cpp/OBJParse.h
@@ -54,7 +54,7 @@ public:
     };
 
     std::vector<VertexAttributes> vertexData;
-    std::vector<unsigned int> indexData;
+    std::vector<unsigned short> indexData;
 private:
     std::vector<std::vector<float> > obj_v;
     std::vector<std::vector<float> > obj_vn;
@@ -62,7 +62,7 @@ private:
     std::vector<std::vector<uint32_t> > obj_f;
 
     std::map<VertexKey, VertexAttributes, VertexKeyCompare> vertexDataMap;
-    std::map<VertexKey, unsigned int, VertexKeyCompare> indexDataMap;
+    std::map<VertexKey, unsigned short, VertexKeyCompare> indexDataMap;
 };
 
 


### PR DESCRIPTION
glDrawElements() on GL ES 2.0 does not support the GL_UNSIGNED_INT type
(support is enabled with extension GL_OES_element_index_uint).
This change modifies the OBJ loader and renderer to use 16-bit indices
so that the app works on contexts without that extension (specifically,
ANGLE on Android using the Vulkan backend).